### PR TITLE
actualise packages

### DIFF
--- a/KBL.Framework/KBL.Framework.BAL.Base/KBL.Framework.BAL.Base.csproj
+++ b/KBL.Framework/KBL.Framework.BAL.Base/KBL.Framework.BAL.Base.csproj
@@ -9,9 +9,9 @@
   <ItemGroup>
     <PackageReference Include="KBL.ExceptionManager" Version="0.9.7" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="NLog" Version="4.5.11" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="NLog" Version="4.7.5" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.6.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KBL.Framework/KBL.Framework.BAL.Interfaces/KBL.Framework.BAL.Interfaces.csproj
+++ b/KBL.Framework/KBL.Framework.BAL.Interfaces/KBL.Framework.BAL.Interfaces.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="8.0.0" />
+    <PackageReference Include="AutoMapper" Version="10.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KBL.Framework/KBL.Framework.DAL.Base/KBL.Framework.DAL.Base.csproj
+++ b/KBL.Framework/KBL.Framework.DAL.Base/KBL.Framework.DAL.Base.csproj
@@ -5,14 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="1.50.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="NLog" Version="4.5.11" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.3.0" />
-    <PackageReference Include="Polly" Version="6.1.2" />
+    <PackageReference Include="Dapper" Version="2.0.78" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="NLog" Version="4.7.5" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.6.5" />
+    <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KBL.Framework/KBL.Framework.DAL.Base/Repositories/BaseCrudRepository.cs
+++ b/KBL.Framework/KBL.Framework.DAL.Base/Repositories/BaseCrudRepository.cs
@@ -6,6 +6,7 @@ using KBL.Framework.DAL.Interfaces.Infrastructure;
 using KBL.Framework.DAL.Interfaces.Repositories;
 using Microsoft.Extensions.Configuration;
 using Polly;
+using Polly.Retry;
 using System;
 using System.Data;
 using System.Data.SqlClient;
@@ -24,7 +25,7 @@ namespace KBL.Framework.DAL.Base.Repositories
         protected IDbTransaction _transaction;
         protected string _tableName;
         protected Policy _retryPolicy;
-        protected Policy _retryPolicyAsync;
+        protected AsyncRetryPolicy _retryPolicyAsync;
         #endregion
 
         #region Properties

--- a/KBL.Framework/KBL.Framework.DAL.Base/Repositories/BaseQueryRepository.cs
+++ b/KBL.Framework/KBL.Framework.DAL.Base/Repositories/BaseQueryRepository.cs
@@ -6,6 +6,7 @@ using KBL.Framework.DAL.Interfaces.Queries;
 using KBL.Framework.DAL.Interfaces.Repositories;
 using Microsoft.Extensions.Configuration;
 using Polly;
+using Polly.Retry;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -25,7 +26,7 @@ namespace KBL.Framework.DAL.Base.Repositories
         //protected string _connectionString;
         protected string _keyColumnName = "";
         protected Policy _retryPolicy;
-        protected Policy _retryPolicyAsync;
+        protected AsyncRetryPolicy _retryPolicyAsync;
         #endregion
 
         #region Properties

--- a/nuget/Package.nuspec
+++ b/nuget/Package.nuspec
@@ -14,16 +14,16 @@
     <projectUrl>https://github.com/KBL-Framework/KBL.Framework</projectUrl>
     <dependencies>      
       <dependency id="KBL.ExceptionManager" version="0.9.7" />
-      <dependency id="NLog" version="4.5.11" />
-      <dependency id="NLog.Extensions.Logging" version="1.3.0" />
-      <dependency id="Dapper" version="1.50.5" />
-      <dependency id="Microsoft.Extensions.Configuration" version="2.2.0" />
+      <dependency id="NLog" version="4.7.5" />
+      <dependency id="NLog.Extensions.Logging" version="1.6.5" />
+      <dependency id="Dapper" version="2.0.78" />
+      <dependency id="Microsoft.Extensions.Configuration" version="5.0.0" />
       <dependency id="System.Data.Common" version="4.3.0" />
-      <dependency id="System.Data.SqlClient" version="4.6.0" />
-      <dependency id="AutoMapper" version="8.0.0" />
-      <dependency id="Newtonsoft.Json" version="12.0.1" />
+      <dependency id="System.Data.SqlClient" version="4.8.2" />
+      <dependency id="AutoMapper" version="10.1.1" />
+      <dependency id="Newtonsoft.Json" version="12.0.3" />
       <dependency id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.2.0" />
-      <dependency id="Polly" version="6.1.2" />
+      <dependency id="Polly" version="7.2.1" />
     </dependencies>
   </metadata>  
 </package>


### PR DESCRIPTION
Problem with mishmash version Automapper 8.0 and 10.1
Calling Services.GetAll() return error: **{"error":"Method not found: '!!0 AutoMapper.IMapper.Map(System.Object)'."}**
Please relase and tag in Github version 2.2.0